### PR TITLE
refactor: move cypress selectors to a separate constants file

### DIFF
--- a/cypress/e2e/add-and-delete-a-task.cy.ts
+++ b/cypress/e2e/add-and-delete-a-task.cy.ts
@@ -1,41 +1,43 @@
+import { selectors } from "../support/selectors";
+
 it("adds and deletes a task", () => {
   // using the data-cy selectors from the src/ folder
   // visit the app
   cy.visit("/");
 
   // confirm the list-view is visible
-  cy.get('[data-cy="list-view"]').should("be.visible");
+  cy.get(selectors.ListView.container).should("be.visible");
 
   // click the create task button
-  cy.get('[data-cy="create-task-button"]').click();
+  cy.get(selectors.CreateTaskButton.button).click();
 
   // confirm the task form is visible
-  cy.get('[data-cy="task-form"]').should("be.visible");
+  cy.get(selectors.TaskForm.container).should("be.visible");
 
   // within the form:
-  cy.get('[data-cy="task-form"]').within(() => {
+  cy.get(selectors.TaskForm.container).within(() => {
     // enter a title
-    cy.get('input[name="title"]').type("Test Task");
+    cy.get(selectors.TaskForm.titleInput).type("Test Task");
 
     // enter a description
-    cy.get('textarea[name="description"]').type("This is a test task description");
+    cy.get(selectors.TaskForm.descriptionInput).type("This is a test task description");
 
     // select a status from the dropdown
-    cy.get('[data-cy="status-select"]').select("In Progress");
+    cy.get(selectors.TaskForm.statusSelect).select("In Progress");
 
     // select a priority from the dropdown
-    cy.get('[data-cy="priority-select"]').select("High");
+    cy.get(selectors.TaskForm.prioritySelect).select("High");
 
     // click the create task button
-    cy.get('[data-cy="submit-task-button"]').click();
+    cy.get(selectors.TaskForm.submitButton).click();
   });
 
   // confirm the task is visible in the list-view
-  cy.get('[data-cy="task-row"]').should("contain", "Test Task");
+  cy.get(selectors.ListView.taskRow).should("contain", "Test Task");
 
   // click the delete button
-  cy.get('[data-cy="delete-task-button"]').first().click();
+  cy.get(selectors.DeleteTaskButton.button).first().click();
 
   // confirm the task is no longer visible in the list-view
-  cy.get('[data-cy="task-row"]').should("not.exist");
+  cy.get(selectors.ListView.taskRow).should("not.exist");
 });

--- a/cypress/support/selectors.ts
+++ b/cypress/support/selectors.ts
@@ -1,0 +1,20 @@
+export const selectors = {
+  ListView: {
+    container: '[data-cy="list-view"]',
+    taskRow: '[data-cy="task-row"]',
+  },
+  TaskForm: {
+    container: '[data-cy="task-form"]',
+    titleInput: 'input[name="title"]',
+    descriptionInput: 'textarea[name="description"]',
+    statusSelect: '[data-cy="status-select"]',
+    prioritySelect: '[data-cy="priority-select"]',
+    submitButton: '[data-cy="submit-task-button"]',
+  },
+  CreateTaskButton: {
+    button: '[data-cy="create-task-button"]',
+  },
+  DeleteTaskButton: {
+    button: '[data-cy="delete-task-button"]',
+  },
+} as const;


### PR DESCRIPTION
This PR moves all Cypress selectors into a separate constants file, grouped by component name. This improves maintainability and reusability of selectors across tests.